### PR TITLE
Fix broken require_once paths in process_articles.php and add AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Project overview
+
+Klutch Products (KBM) is a vanilla PHP application for automating affiliate link and blog post generation for Amazon products. See `README.md` for full details.
+
+### Running the dev server
+
+```sh
+php -S 0.0.0.0:8000 -t KBM/public/
+```
+
+The main entry point is `KBM/public/index.php`, which reads JSON article data from `KBM/klutch_articles_json/` and renders Bootstrap-styled product cards.
+
+### Lint
+
+There is no dedicated linter configured. Use `php -l <file>` for syntax checking PHP files. Example:
+
+```sh
+find . -name '*.php' -not -path './vendor/*' -exec php -l {} \;
+```
+
+### Tests
+
+No automated test suite exists in this project. Validate manually by running the dev server and loading the page.
+
+### Key caveats
+
+- **No PostgreSQL required for the web frontend.** The main entry point (`KBM/public/index.php`) reads directly from JSON files and does not require a database. The CLI script `process_articles_cli.php` does require PostgreSQL and `.env` configuration (DB_HOST, DB_PORT, DB_DATABASE, DB_USERNAME, DB_PASSWORD).
+- **`Views/api.php` uses `getallheaders()`** which is only available in web server context (Apache/CGI/PHP built-in server), not CLI. This file cannot be tested via `php Views/api.php`.
+- **`B0899YYSXV.json` contains invalid JSON** (`NaN` value in the `"Added to Website?"` field). PHP's `json_decode` will silently fail on this file and it will be skipped by the article processor.
+- **Composer vendor directory:** `.gitignore` excludes `/vendor/` but the lockfile is committed. Always run `composer install` after pulling.

--- a/KBM/src/helpers/process_articles.php
+++ b/KBM/src/helpers/process_articles.php
@@ -1,9 +1,5 @@
 <?php
 
-require_once __DIR__ . '/../src/helpers/process_articles.php';
-require_once __DIR__ . '/../src/models/ArticleList.php';
-
-// Define the processArticleFiles function
 function processArticleFiles($folderPath)
 {
     $files = scandir($folderPath);
@@ -22,43 +18,3 @@ function processArticleFiles($folderPath)
     }
     return $results;
 }
-
-// Process JSON files and get article data
-$folderPath = __DIR__ . '/../klutch_articles_json';
-$results = processArticleFiles($folderPath);
-
-// Extract valid articles
-$validArticles = [];
-foreach ($results as $result) {
-    if ($result['status'] === 'success') {
-        $validArticles[] = $result['data'];
-    }
-    /* The `}` in the PHP code is used to close the opening curly brace `{` that starts a block of code. In
-this specific context, the `}` is closing the block of code that contains the foreach loop where
-valid articles are being extracted from the results array. This ensures that the code within the
-foreach loop is executed for each element in the results array, and the closing curly brace marks
-the end of that loop. */
-}
-
-// Create ArticleList instance
-$articleList = new ArticleList($validArticles);
-
-?>
-<!DOCTYPE html>
-<html lang="en">
-
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Klutch Articles</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
-</head>
-
-<body>
-    <div class="container">
-        <h1 class="my-4">Klutch Articles</h1>
-        <?php echo $articleList->renderList(); ?>
-    </div>
-</body>
-
-</html>

--- a/vendor/autoload.php
+++ b/vendor/autoload.php
@@ -14,10 +14,7 @@ if (PHP_VERSION_ID < 50600) {
             echo $err;
         }
     }
-    trigger_error(
-        $err,
-        E_USER_ERROR
-    );
+    throw new RuntimeException($err);
 }
 
 require_once __DIR__ . '/composer/autoload_real.php';

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -13,56 +13,56 @@ class ComposerStaticInit7552acdc1b0f6b9b861c48539a840ef0
     );
 
     public static $prefixLengthsPsr4 = array (
-        'S' => 
+        'S' =>
         array (
             'Symfony\\Polyfill\\Php80\\' => 23,
             'Symfony\\Polyfill\\Mbstring\\' => 26,
             'Symfony\\Polyfill\\Ctype\\' => 23,
         ),
-        'P' => 
+        'P' =>
         array (
             'PhpOption\\' => 10,
         ),
-        'G' => 
+        'G' =>
         array (
             'GrahamCampbell\\ResultType\\' => 26,
         ),
-        'D' => 
+        'D' =>
         array (
             'Dotenv\\' => 7,
         ),
-        'A' => 
+        'A' =>
         array (
             'Aj\\Kbm\\' => 7,
         ),
     );
 
     public static $prefixDirsPsr4 = array (
-        'Symfony\\Polyfill\\Php80\\' => 
+        'Symfony\\Polyfill\\Php80\\' =>
         array (
             0 => __DIR__ . '/..' . '/symfony/polyfill-php80',
         ),
-        'Symfony\\Polyfill\\Mbstring\\' => 
+        'Symfony\\Polyfill\\Mbstring\\' =>
         array (
             0 => __DIR__ . '/..' . '/symfony/polyfill-mbstring',
         ),
-        'Symfony\\Polyfill\\Ctype\\' => 
+        'Symfony\\Polyfill\\Ctype\\' =>
         array (
             0 => __DIR__ . '/..' . '/symfony/polyfill-ctype',
         ),
-        'PhpOption\\' => 
+        'PhpOption\\' =>
         array (
             0 => __DIR__ . '/..' . '/phpoption/phpoption/src/PhpOption',
         ),
-        'GrahamCampbell\\ResultType\\' => 
+        'GrahamCampbell\\ResultType\\' =>
         array (
             0 => __DIR__ . '/..' . '/graham-campbell/result-type/src',
         ),
-        'Dotenv\\' => 
+        'Dotenv\\' =>
         array (
             0 => __DIR__ . '/..' . '/vlucas/phpdotenv/src',
         ),
-        'Aj\\Kbm\\' => 
+        'Aj\\Kbm\\' =>
         array (
             0 => __DIR__ . '/../..' . '/src',
         ),


### PR DESCRIPTION
- Remove erroneous require_once lines from KBM/src/helpers/process_articles.php that referenced non-existent paths (__DIR__/../src/ resolved to src/src/)
- Remove duplicated entry point code (HTML template + processing logic) that was accidentally left in the helper file
- Keep only the processArticleFiles() function definition, which is what KBM/public/index.php expects when including this helper
- Add AGENTS.md with Cursor Cloud development environment instructions